### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Example Apple TV app showing IMDB movies
 
 Based upon tutorial from Mark Price at https://www.youtube.com/watch?v=XmLdEcq-QNI&feature=youtu.be&a
 
-#Improvements
+# Improvements
 @insanoid: Added focus animation property to images
 
 # License


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
